### PR TITLE
release zipfile for xlsx

### DIFF
--- a/xlrd/__init__.py
+++ b/xlrd/__init__.py
@@ -119,6 +119,7 @@ def open_workbook(filename=None, logfile=sys.stdout, verbosity=0, use_mmap=True,
                 on_demand=on_demand,
                 ragged_rows=ragged_rows,
             )
+            zf.close()
             return bk
         if 'xl/workbook.bin' in component_names:
             raise XLRDError('Excel 2007 xlsb file; not supported')


### PR DESCRIPTION
When opening .xlsx files with xlrd3.open_workbook, the file remains locked and cannot be deleted because the zipfile object is not properly closed after opening in __init__.py. This results in the file being kept in use. Add a zf.close() can close the zipfile object after it is used. With this change, the .xlsx file is not locked after opening and can be celeted successfully.